### PR TITLE
Fix FirstCh type

### DIFF
--- a/lib/syobocal/db.rb
+++ b/lib/syobocal/db.rb
@@ -79,7 +79,7 @@ module Syobocal
             "FirstMonth" => :int,
             "FirstEndYear" => :int,
             "FirstEndMonth" => :int,
-            "FirstCh" => :int,
+            "FirstCh" => :str,
             "Keywords" => :str,
             "UserPoint" => :int,
             "UserPointRank" => :int,


### PR DESCRIPTION
db.php, Command=TitleLookup において、
FirstChには放送局名が文字列で入ってくるようです。
typeがintだと値が一律0になってしまっています。
よろしくお願いいたします。
