### PR TITLE
Fix JSON::ProgramByDate

### DIFF
--- a/bin/syobocal
+++ b/bin/syobocal
@@ -101,9 +101,9 @@ when "JSON::ProgramByCount"
   puts Syobocal::JSON::ProgramByCount.url(params)
   result = Syobocal::JSON::ProgramByCount.get(params)
   pp result
-when "JSON::ProgramByData"
-  puts Syobocal::JSON::ProgramByData.url(params)
-  result = Syobocal::JSON::ProgramByData.get(params)
+when "JSON::ProgramByDate"
+  puts Syobocal::JSON::ProgramByDate.url(params)
+  result = Syobocal::JSON::ProgramByDate.get(params)
   pp result
 when "JSON::SubTitles"
   puts Syobocal::JSON::SubTitles.url(params)

--- a/lib/syobocal/json.rb
+++ b/lib/syobocal/json.rb
@@ -86,7 +86,7 @@ module Syobocal
       end
 
       def url(params = {})
-        'http://cal.syoboi.jp/json.php?Req=ProgramByData' + Syobocal::Util.format_params_amp(params)
+        'http://cal.syoboi.jp/json.php?Req=ProgramByDate' + Syobocal::Util.format_params_amp(params)
       end
 
       def parse(json)


### PR DESCRIPTION
Syobocal::JSON::ProgramByDateについて以下により正しく動作しなかったため、修正させて頂きました。

- URLがtypoしていた
- bin/syobocalのコマンド及び呼び出しがそれぞれ「~Date」ではなく、「~Data」になっていた

よろしければご確認お願い致します。